### PR TITLE
fixed missing crc32 libs after upgrade

### DIFF
--- a/roles/base/files/etc/modules-load.d/batman.conf
+++ b/roles/base/files/etc/modules-load.d/batman.conf
@@ -1,3 +1,1 @@
-libcrc32c
-crc32c
 batman-adv


### PR DESCRIPTION
after upgrading arch, the crc32 libs are not necessary anymore
