### PR TITLE
systemctl restart issue

### DIFF
--- a/roles/icvpn/files/post-merge/icvpn-meta
+++ b/roles/icvpn/files/post-merge/icvpn-meta
@@ -10,8 +10,8 @@ DATA=$(git rev-parse --show-toplevel)
 ../icvpn-scripts/mkroa -s $DATA -x luebeck -m 64 > /etc/bird/roa.ip6
 ../icvpn-scripts/mkroa -s $DATA -x luebeck -m 32 -4 > /etc/bird/roa.ip4
 
-systemctl reload named.service
-systemctl reload bird6.service
-systemctl reload bird.service
+systemctl try-reload-or-restart named.service
+systemctl try-reload-or-restart bird6.service
+systemctl try-reload-or-restart bird.service
 
 exit 0


### PR DESCRIPTION
systemctl restart nicht möglich nach einrichten, da service noch nicht gestartet. jetzt try-reload-or-restart.